### PR TITLE
updated so that underline and strikethrough use `NSUnderlineStyle`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ profile
 DerivedData
 *.hmap
 *.ipa
+.build
 
 # Bundler
 .bundle

--- a/AttributedStringBuilder/AttributedStringBuilder/AttributedStringBuilder.swift
+++ b/AttributedStringBuilder/AttributedStringBuilder/AttributedStringBuilder.swift
@@ -130,8 +130,10 @@ public class AttributedStringBuilder {
     // MARK: - Properties
 
     private var masterAttributedString = NSMutableAttributedString()
+    private var masterAccessibilityStrings: [String] = []
     
     public var attributedString: NSAttributedString {
+        masterAttributedString.accessibilityLabel = masterAccessibilityStrings.joined(separator: ", ")
         return masterAttributedString
     }
     
@@ -147,17 +149,22 @@ public class AttributedStringBuilder {
     
     public init() {}
     
-    @discardableResult public func text(_ string: String, attributes: [Attribute] = []) -> AttributedStringBuilder {
+    @discardableResult public func text(_ string: String, attributes: [Attribute] = [], accessibilityString: String? = nil) -> AttributedStringBuilder {
         
         let attributes = attributesDictionary(withOverrides: attributes)
         let attributedString = NSAttributedString(string: string, attributes: attributes)
+
         masterAttributedString.append(attributedString)
+        masterAccessibilityStrings.append(accessibilityString ?? string)
+
         return self
     }
     
-    @discardableResult public func attributedText(_ attributedString: NSAttributedString) -> AttributedStringBuilder {
+    @discardableResult public func attributedText(_ attributedString: NSAttributedString, accessibilityString: String? = nil) -> AttributedStringBuilder {
         
         masterAttributedString.append(attributedString)
+        masterAccessibilityStrings.append(accessibilityString ?? attributedString.string)
+        
         return self
     }
     

--- a/AttributedStringBuilder/AttributedStringBuilder/AttributedStringBuilder.swift
+++ b/AttributedStringBuilder/AttributedStringBuilder/AttributedStringBuilder.swift
@@ -155,7 +155,7 @@ public class AttributedStringBuilder {
         let attributedString = NSAttributedString(string: string, attributes: attributes)
 
         masterAttributedString.append(attributedString)
-        masterAccessibilityStrings.append(accessibilityString ?? string)
+        appendAccessibilityString(accessibilityString, attributedStringText: string)
 
         return self
     }
@@ -163,7 +163,7 @@ public class AttributedStringBuilder {
     @discardableResult public func attributedText(_ attributedString: NSAttributedString, accessibilityString: String? = nil) -> AttributedStringBuilder {
         
         masterAttributedString.append(attributedString)
-        masterAccessibilityStrings.append(accessibilityString ?? attributedString.string)
+        appendAccessibilityString(accessibilityString, attributedStringText: attributedString.string)
         
         return self
     }
@@ -178,7 +178,7 @@ public class AttributedStringBuilder {
     }
     
     @discardableResult public func space(attributes: [Attribute] = []) -> AttributedStringBuilder {
-        return text(" ", attributes: attributes)
+        return text(" ", attributes: attributes, accessibilityString: "")
     }
     
     @discardableResult public func newlines(_ number: Int, attributes: [Attribute] = []) -> AttributedStringBuilder {
@@ -191,7 +191,7 @@ public class AttributedStringBuilder {
     }
     
     @discardableResult public func newline(attributes: [Attribute] = []) -> AttributedStringBuilder {
-        return text("\n", attributes: attributes)
+        return text("\n", attributes: attributes, accessibilityString: "")
     }
     
     @discardableResult public func tabs(_ number: Int, attributes: [Attribute] = []) -> AttributedStringBuilder {
@@ -283,5 +283,16 @@ public class AttributedStringBuilder {
         
         return attributesDict
     }
-    
+
+    private func appendAccessibilityString(_ accessibilityString: String?, attributedStringText: String) {
+        if let accessibilityString = accessibilityString {
+            if accessibilityString.isEmpty {
+                return
+            } else {
+                masterAccessibilityStrings.append(accessibilityString)
+            }
+        } else {
+            masterAccessibilityStrings.append(attributedStringText)
+        }
+    }
 }

--- a/AttributedStringBuilder/AttributedStringBuilder/AttributedStringBuilder.swift
+++ b/AttributedStringBuilder/AttributedStringBuilder/AttributedStringBuilder.swift
@@ -31,8 +31,8 @@ public class AttributedStringBuilder {
         case backgroundColor(UIColor?)          // NSBackgroundColorAttributeName
         case ligitures(Bool)                    // NSLigatureAttributeName
         case kerning(CGFloat)                   // NSKernAttributeName
-        case strikethrough(Bool)                // NSStrikethroughStyleAttributeName
-        case underline(Bool)                    // NSUnderlineStyleAttributeName
+        case strikethrough(NSUnderlineStyle)    // NSStrikethroughStyleAttributeName
+        case underline(NSUnderlineStyle)        // NSUnderlineStyleAttributeName
         case strokeColor(UIColor)               // NSStrokeColorAttributeName
         case strokeWidth(CGFloat)               // NSStrokeWidthAttributeName
         case shadow(NSShadow?)                  // NSShadowAttributeName


### PR DESCRIPTION
underline and strikethrough styles were taking a Bool value, but they can/should be using values as seen in `NSUnderlineStyle`. This will allow for different variations in the lines that get drawn, and matches the built-in behavior.

This is a breaking change, and people will need to use values such as `.single` `.thick`, `.double` etc., instead of boolean value. 