### PR TITLE
Underline attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ profile
 DerivedData
 *.hmap
 *.ipa
+.build
 
 # Bundler
 .bundle

--- a/AttributedStringBuilder/AttributedStringBuilder/AttributedStringBuilder.swift
+++ b/AttributedStringBuilder/AttributedStringBuilder/AttributedStringBuilder.swift
@@ -84,9 +84,9 @@ public class AttributedStringBuilder {
             case .kerning(let value):
                 return (.kern, value)
             case .strikethrough(let value):
-                return (.strikethroughStyle, value)
+                return (.strikethroughStyle, value.rawValue)
             case .underline(let value):
-                return (.underlineStyle, value)
+                return (.underlineStyle, value.rawValue)
             case .strokeColor(let value):
                 return (.strokeColor, value)
             case .strokeWidth(let value):

--- a/AttributedStringBuilder/AttributedStringBuilder/AttributedStringBuilder.swift
+++ b/AttributedStringBuilder/AttributedStringBuilder/AttributedStringBuilder.swift
@@ -31,8 +31,8 @@ public class AttributedStringBuilder {
         case backgroundColor(UIColor?)          // NSBackgroundColorAttributeName
         case ligitures(Bool)                    // NSLigatureAttributeName
         case kerning(CGFloat)                   // NSKernAttributeName
-        case strikethrough(Bool)                // NSStrikethroughStyleAttributeName
-        case underline(Bool)                    // NSUnderlineStyleAttributeName
+        case strikethrough(NSUnderlineStyle)    // NSStrikethroughStyleAttributeName
+        case underline(NSUnderlineStyle)        // NSUnderlineStyleAttributeName
         case strokeColor(UIColor)               // NSStrokeColorAttributeName
         case strokeWidth(CGFloat)               // NSStrokeWidthAttributeName
         case shadow(NSShadow?)                  // NSShadowAttributeName

--- a/Example/Example.playground/Pages/Awesome Things.xcplaygroundpage/Contents.swift
+++ b/Example/Example.playground/Pages/Awesome Things.xcplaygroundpage/Contents.swift
@@ -41,7 +41,7 @@ let awesomeAttributes: [AttributedStringBuilder.Attribute] = [
     .kerning(5),
     .shadow(shadow),
     .skew(0.3),
-    .underline(true)
+    .underline(.single)
 ]
 /*:
  **Build the string**

--- a/Example/Example.playground/Pages/Basic Example 2.xcplaygroundpage/Contents.swift
+++ b/Example/Example.playground/Pages/Basic Example 2.xcplaygroundpage/Contents.swift
@@ -19,7 +19,7 @@ builder.defaultAttributes = [
  */
 builder
     .text("It's ")
-    .text("Easy ", attributes: [.underline(true), .textColor(UIColor.blue)])
+    .text("Easy ", attributes: [.underline(.single), .textColor(UIColor.blue)])
     .text("To ", attributes: [.strokeWidth(2), .textColor(UIColor.black)])
     .text("Adjust ", attributes: [.skew(0.3), .textColor(UIColor.magenta)])
     .text("Attributes ", attributes: [.font(UIFont(name: "Baskerville-Bold", size: 30)!)])

--- a/Example/ImagesExample/ImagesExample/ViewController.swift
+++ b/Example/ImagesExample/ImagesExample/ViewController.swift
@@ -25,7 +25,7 @@ class ViewController: UIViewController {
         let builder = AttributedStringBuilder()
         builder.defaultAttributes = [
             .font(font),
-            .underline(true),
+            .underline(.single),
             .textColor(UIColor.purple)
         ]
         

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ builder.defaultAttributes = [
 
 builder
     .text("It's ")
-    .text("Easy ", attributes: [.underline(true), .textColor(UIColor.blue)])
+    .text("Easy ", attributes: [.underline(.single), .textColor(UIColor.blue)])
     .text("To ", attributes: [.strokeWidth(2), .textColor(UIColor.black)])
     .text("Adjust ", attributes: [.skew(0.3), .textColor(UIColor.magenta)])
     .text("Attributes ", attributes: [.font(UIFont(name: "Baskerville-Bold", size: 30)!)])
@@ -105,7 +105,7 @@ let awesomeAttributes: [AttributedStringBuilder.Attribute] = [
     .kerning(5),
     .shadow(shadow),
     .skew(0.3),
-    .underline(true)
+    .underline(.single)
 ]
 
 // Build the string
@@ -130,7 +130,7 @@ let font = UIFont.systemFont(ofSize: 90)
 let builder = AttributedStringBuilder()
 builder.defaultAttributes = [
     .font(font),
-    .underline(true),
+    .underline(.single),
     .textColor(UIColor.purple)
 ]
         


### PR DESCRIPTION
changed how `.underline` and `.strikethrough` attributes were used. Allowing the use of `NSUnderlineStyle` for both, so people can use a variety of styles for these lines.